### PR TITLE
remove .forumposts .poster background from index_light.css

### DIFF
--- a/css/_light/index_light.css
+++ b/css/_light/index_light.css
@@ -1245,10 +1245,6 @@ div.bbc_footnotes .meaction{
 	background: #fff5cd;
 }
 
-.forumposts .poster {
-	background: #e1e3ef;
-}
-
 /* @todo - Add an h3 for a11y? Breaks Stoopidfish. Bleh. :P */
 .poster .name {
 	color: #3c6582;


### PR DESCRIPTION
I noticed these background colours behind our username/avatars look a bit ugly so perhaps they could be removed?

Before / After
![](http://i.imgur.com/qPlXBMX.png) ![](http://i.imgur.com/iTOWuMm.png)