### PR TITLE
Post user details area full-height background color

### DIFF
--- a/css/_light/index_light.css
+++ b/css/_light/index_light.css
@@ -1225,24 +1225,31 @@ div.bbc_footnotes .meaction{
 	box-shadow: 1px 2px 4px #eee;
 }
 /* Poster and postarea + moderation area underneath */
-.forumposts .windowbg, .forumposts .windowbg2,
-.forumposts .approvebg, .forumposts .approvebg2, .core_posts {
-	border: 1px solid #ddd;
-	border-bottom: 1px solid #ccc;
-	background: #f0f0f0;
+
+/* Color for left-of-post user details full-height background */
+.forumposts .windowbg,
+.forumposts .windowbg2,
+.forumposts .approvebg,
+.forumposts .approvebg2 {
+    background-color: #e7eaef;
+    padding: 0;
+}
+.forumposts .windowbg .postarea, .forumposts .windowbg2 .postarea,
+.forumposts .approvebg .postarea, .forumposts .approvebg2 .postarea, .core_posts {
+    background: #f0f0f0;
 }
 
-.forumposts .windowbg, .forumposts .approvebg {
-	background: #f0f0f0;
+.forumposts .windowbg .postarea, .forumposts .approvebg .postarea {
+    background: #f0f0f0;
 }
 
-.forumposts .windowbg2, .forumposts .approvebg2 {
-	background: #eff1f3;
+.forumposts .windowbg2 .postarea, .forumposts .approvebg2 .postarea {
+    background: #eff1f3;
 }
 
 /* Colors for background of posts requiring approval */
-.forumposts .approvebg, .forumposts .approvebg2 {
-	background: #fff5cd;
+.forumposts .approvebg .postare, .forumposts .approvebg2 .postarea {
+    background: #fff5cd;
 }
 
 /* @todo - Add an h3 for a11y? Breaks Stoopidfish. Bleh. :P */

--- a/css/index.css
+++ b/css/index.css
@@ -2181,6 +2181,7 @@ div.core_posts {
 	-moz-hyphens: auto;
 	-ms-hyphens: auto;
 	font-size: 0.857em;
+	margin-top: 1em;
 }
 .poster.poster2 {
 	display: block;
@@ -2289,12 +2290,12 @@ div.core_posts {
 .postarea {
 	display: block;
 	margin: 0 0 0 13em;
-	padding: 0 1em 0 1.5em;
+	padding: 1em 1em 1em 1.5em;
 	max-width: 100%;
 }
 .postarea2 {
 	display: block;
-	padding: 0 1em;
+	padding: 1em 1em;
 }
 
 #topic_summary .postarea2 {


### PR DESCRIPTION
Makes the user details (name, avatar) area to the left of posts have a
full-height background color by changing the post and post container
colors, padding and margins.