### PR TITLE
Removing extra intermediate small width Recent Topics media query

### DIFF
--- a/css/portal.css
+++ b/css/portal.css
@@ -869,9 +869,6 @@ dl.sp_form img, #sp_add_articles_list_header img {
 	#sp_collapse_side1, #sp_collapse_side2, #sp_collapse_side3, #sp_collapse_side4 {
 		padding: 6px;
 	}
-	.sp_recent_replies:before  {
-		content: "Replies: "
-	}
 }
 
 
@@ -900,6 +897,9 @@ dl.sp_form img, #sp_add_articles_list_header img {
 	.sp_recent_starter:before {
 		content: "Topic starter: "
 	}
+	.sp_recent_replies:before  {
+		content: "Replies: "
+	}
 	.sp_recent_poster:before {
 		content: "Latest post by: "
 	}
@@ -926,79 +926,6 @@ dl.sp_form img, #sp_add_articles_list_header img {
 	}
 	.sp_recent_poster.righttext time:before {
 		content: " "
-	}
-	.sp_recent_poster time {
-		font-style:italic;
-	}
-}
-
-@media screen and (min-width: 32em) and (max-width: 55em)
-{
-	
-	.sp_recent_header {
-		display: none;
-	}
-	.sp_recent td {
-		display: inline;
-	}
-	.sp_recent_subject:before {
-		font-weight: bold;
-		content: "Topic subject: "
-	}
-	a[href$="#new"] {
-		margin-left: 0.25em;
-	}
-	.sp_recent_board:before {
-		font-weight: bold;
-		content: "Forum: "
-	}
-	.sp_recent_starter:before {
-		font-weight: bold;
-		content: "Topic starter: "
-	}
-	.sp_recent_starter:after {
-		font-weight: bold;
-		content: "Replies:"
-	}
-	.sp_recent_poster:before {
-		font-weight: bold;
-		content: "Latest post by: "
-	}
-	.sp_recent_info.righttext {
-		margin-left:-1px;
-		text-align: left;
-		display: block;
-		padding-right: 10px !important;
-	}
-	.sp_recent_info.righttext  .sp_recent_label {
-		padding-right: 5px;
-	}
-	.sp_recent_info.righttext a {
-		float: left !important;
-	}
-	.sp_recent_info.righttext a:before {
-		content: "Latest post by: "
-	}
-	.sp_recent_poster.righttext br {
-		display: none;
-	}
-	.sp_recent_poster.righttext time:before {
-		content: " "
-	}
-	.sp_recent_info.righttext {
-		margin-left:-1px;
-		text-align: left;
-		display: block;
-		padding-right: 10px !important;
-	}
-	.sp_recent_info.righttext  .sp_recent_label {
-		padding-right: 5px;
-	}
-	.sp_recent_info.righttext a {
-		float: left !important;
-	}
-	.sp_recent_info.righttext>a:before {
-		content: "Latest post by: "
 	}
 	.sp_recent_poster time {
 		font-style:italic;


### PR DESCRIPTION
The 32em-55em width query isn't really needed now as the new `max-width: 55em` query handles it, and by itself is pretty hard to read. Unless @kddlb has a specific reason to keep it.

Also looks like 'Last post' was changed to 'Latest' though the column headers still say 'Last'. May need to update the header for consistency.

Existing:

![Existing](http://i.imgur.com/LQ1xnUl.jpg)

Changes:

![Changes](http://i.imgur.com/Kp8IXJQ.jpg)

