### PR TITLE
Use normal font in 'Recent topics>Latest post' column

### DIFF
--- a/css/portal.css
+++ b/css/portal.css
@@ -148,9 +148,6 @@ tr.sp_recent:nth-child(even) {
 	text-align: left;
 	white-space: nowrap;
 }
-.sp_recent_poster a {
-	font-weight: bold;
-}
 .sp_image {
 	text-align: center;
 	line-height: 1.4em;


### PR DESCRIPTION
The bold font in the "Latest post" columns looks wrong to me...

Before/after
![untitled](https://cloud.githubusercontent.com/assets/12451008/12222713/276353ee-b7bc-11e5-96b9-98ee3a46c41a.png)
