### PR TITLE
Category heading text shadows softened, made transparent

### DIFF
--- a/css/_light/index_light.css
+++ b/css/_light/index_light.css
@@ -214,7 +214,7 @@ strong {
 	background: #5176b5;
 	background-image: linear-gradient(to bottom, #618dd9, #4f73b0);
 	color: #fff;
-	text-shadow: 1px 1px 0 #112;
+	text-shadow: 1px 1px 1px hsla(0,0%,0%,0.3);
 }
 /* Single ones a bit darker than board index ones. */
 .forumposts .category_header, .content_category .category_header {


### PR DESCRIPTION
Per carpman's request. Adds HSLa transparency to the widget/topic blue title strip text headings to be less harsh for some. Very subtle in comparison but provides a little more contrast than no shadow at all.